### PR TITLE
backup-restore scripts rework. AI powered.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ ENV AWS_DEFAULT_REGION=us-east-1
 ADD docker_entrypoint.sh /docker_entrypoint.sh
 ADD backup.sh /backup.sh
 ADD restore.sh /restore.sh
+ADD restore_legacy.sh /restore_legacy.sh
 ADD sync.sh /sync.sh
+
+RUN chmod +x /docker_entrypoint.sh /backup.sh /restore.sh /restore_legacy.sh /sync.sh
 
 VOLUME ["/backup"]
 

--- a/backup.sh
+++ b/backup.sh
@@ -1,50 +1,76 @@
 #!/bin/bash
+set -euo pipefail
 
-MONGODB_HOST=${MONGODB_BACKUP_PORT_27017_TCP_ADDR:-${MONGODB_BACKUP_HOST}}
-MONGODB_HOST=${MONGODB_BACKUP_PORT_1_27017_TCP_ADDR:-${MONGODB_BACKUP_HOST}}
-MONGODB_PORT=${MONGODB_BACKUP_PORT_27017_TCP_PORT:-${MONGODB_BACKUP_PORT}}
-MONGODB_PORT=${MONGODB_BACKUP_PORT_1_27017_TCP_PORT:-${MONGODB_BACKUP_PORT}}
-MONGODB_USER=${MONGODB_BACKUP_USER:-${MONGODB_BACKUP_ENV_MONGODB_USER}}
-MONGODB_PASS=${MONGODB_BACKUP_PASS:-${MONGODB_BACKUP_ENV_MONGODB_PASS}}
+# Support old Docker "link" env vars + explicit vars
+MONGODB_HOST="${MONGODB_BACKUP_PORT_27017_TCP_ADDR:-${MONGODB_BACKUP_PORT_1_27017_TCP_ADDR:-${MONGODB_BACKUP_HOST:-}}}"
+MONGODB_PORT="${MONGODB_BACKUP_PORT_27017_TCP_PORT:-${MONGODB_BACKUP_PORT_1_27017_TCP_PORT:-${MONGODB_BACKUP_PORT:-27017}}}"
 
-[[ ( -z "${MONGODB_BACKUP_USER}" ) && ( -n "${MONGODB_BACKUP_PASS}" ) ]] && MONGODB_BACKUP_USER='admin'
+MONGODB_USER="${MONGODB_BACKUP_USER:-${MONGODB_BACKUP_ENV_MONGODB_USER:-}}"
+MONGODB_PASS="${MONGODB_BACKUP_PASS:-${MONGODB_BACKUP_ENV_MONGODB_PASS:-}}"
+MONGODB_DB="${MONGODB_BACKUP_DB:-}"
 
-[[ ( -n "${MONGODB_BACKUP_USER}" ) ]] && USER_BACKUP_STR=" --username ${MONGODB_BACKUP_USER}"
-[[ ( -n "${MONGODB_BACKUP_PASS}" ) ]] && PASS_BACKUP_STR=" --password ${MONGODB_BACKUP_PASS}"
-[[ ( -n "${MONGODB_BACKUP_DB}" ) ]] && DB_BACKUP_STR=" --db ${MONGODB_BACKUP_DB}"
-
-BACKUP_NAME=$(date +%Y.%m.%d.%H%M%S)
-BACKUP_CMD="mongodump --out /backup/${BACKUP_NAME} --host ${MONGODB_BACKUP_HOST} --port ${MONGODB_BACKUP_PORT} ${USER_BACKUP_STR}${PASS_BACKUP_STR}${DB_BACKUP_STR} ${EXTRA_BACKUP_OPTS}"
-
-echo "=> Backup started"
-if ${BACKUP_CMD} ;then
-
-    echo "   Backup succeeded"
-
-    if [[ -n "$S3_BACKUP" ]]; then
-
-        echo "   Archiving and backing up dump to S3"
-
-        echo "   Creating archive at /backup/${BACKUP_NAME}.tgz"
-        tar czf "/backup/${BACKUP_NAME}.tgz" "/backup/${BACKUP_NAME}"
-
-        echo "   Copying to S3"
-        aws s3 cp "/backup/${BACKUP_NAME}.tgz" s3://$S3_BUCKET/$S3_PATH/${BACKUP_NAME}.tgz
-
-        if [ $? == 0 ]; then
-            rm "/backup/${BACKUP_NAME}.tgz"
-        else
-            >&2 echo "couldn't transfer /backup/${BACKUP_NAME}.tgz to S3"
-        fi
-
-    fi
-
-else
-
-    echo "   Backup failed"
-
+# If password is set but user isn't, default to admin (as in original script)
+if [[ -z "${MONGODB_USER}" && -n "${MONGODB_PASS}" ]]; then
+  MONGODB_USER="admin"
 fi
 
-rm -rf /backup/${BACKUP_NAME}
+# Optional auth DB (recommended). Can also be passed via EXTRA_BACKUP_OPTS.
+MONGODB_AUTH_DB="${MONGODB_AUTH_DB:-${MONGODB_BACKUP_AUTH_DB:-}}"
+
+# Build mongodump args safely
+args=(mongodump
+  "--host" "${MONGODB_HOST}"
+  "--port" "${MONGODB_PORT}"
+)
+
+if [[ -n "${MONGODB_USER}" ]]; then
+  args+=("--username" "${MONGODB_USER}")
+fi
+if [[ -n "${MONGODB_PASS}" ]]; then
+  args+=("--password" "${MONGODB_PASS}")
+fi
+if [[ -n "${MONGODB_AUTH_DB}" ]]; then
+  args+=("--authenticationDatabase" "${MONGODB_AUTH_DB}")
+fi
+if [[ -n "${MONGODB_DB}" ]]; then
+  args+=("--db" "${MONGODB_DB}")
+fi
+
+BACKUP_NAME="$(date +%Y.%m.%d.%H%M%S)"
+ARCHIVE_PATH="/backup/${BACKUP_NAME}.archive.gz"
+
+# Create single-file archive suitable for streaming restore
+args+=("--archive=${ARCHIVE_PATH}" "--gzip")
+
+# Allow extra options (kept compatible with your previous approach: string gets word-split)
+# Examples: EXTRA_BACKUP_OPTS="--readPreference=secondaryPreferred --oplog"
+if [[ -n "${EXTRA_BACKUP_OPTS:-}" ]]; then
+  # shellcheck disable=SC2206
+  extra=( ${EXTRA_BACKUP_OPTS} )
+  args+=("${extra[@]}")
+fi
+
+echo "=> Backup started"
+if "${args[@]}"; then
+  echo "   Backup succeeded: ${ARCHIVE_PATH}"
+
+  if [[ -n "${S3_BACKUP:-}" ]]; then
+    echo "   Copying archive to S3"
+    : "${S3_BUCKET:?S3_BUCKET is required when S3_BACKUP is set}"
+    S3_PATH="${S3_PATH:-}"
+
+    aws s3 cp "${ARCHIVE_PATH}" "s3://${S3_BUCKET}/${S3_PATH%/}/${BACKUP_NAME}.archive.gz"
+
+    echo "   S3 upload succeeded, removing local archive"
+    rm -f "${ARCHIVE_PATH}"
+  else
+    echo "   S3_BACKUP not set; leaving local archive at ${ARCHIVE_PATH}"
+  fi
+else
+  echo "   Backup failed" >&2
+  # Keep any partial file for debugging? remove to match old behavior
+  rm -f "${ARCHIVE_PATH}" || true
+  exit 1
+fi
 
 echo "=> Backup done"

--- a/restore.sh
+++ b/restore.sh
@@ -1,26 +1,97 @@
 #!/bin/bash
+set -euo pipefail
 
-MONGODB_HOST=${MONGODB_RESTORE_PORT_27017_TCP_ADDR:-${MONGODB_RESTORE_HOST}}
-MONGODB_HOST=${MONGODB_RESTORE_PORT_1_27017_TCP_ADDR:-${MONGODB_RESTORE_HOST}}
-MONGODB_PORT=${MONGODB_RESTORE_PORT_27017_TCP_PORT:-${MONGODB_RESTORE_PORT}}
-MONGODB_PORT=${MONGODB_RESTORE_PORT_1_27017_TCP_PORT:-${MONGODB_RESTORE_PORT}}
-MONGODB_USER=${MONGODB_RESTORE_USER:-${MONGODB_RESTORE_ENV_MONGODB_USER}}
-MONGODB_PASS=${MONGODB_RESTORE_PASS:-${MONGODB_RESTORE_ENV_MONGODB_PASS}}
+# Support old Docker "link" env vars + explicit vars
+MONGODB_HOST="${MONGODB_RESTORE_PORT_27017_TCP_ADDR:-${MONGODB_RESTORE_PORT_1_27017_TCP_ADDR:-${MONGODB_RESTORE_HOST:-}}}"
+MONGODB_PORT="${MONGODB_RESTORE_PORT_27017_TCP_PORT:-${MONGODB_RESTORE_PORT_1_27017_TCP_PORT:-${MONGODB_RESTORE_PORT:-27017}}}"
 
-[[ ( -z "${MONGODB_RESTORE_USER}" ) && ( -n "${MONGODB_RESTORE_PASS}" ) ]] && MONGODB_RESTORE_USER='admin'
+MONGODB_USER="${MONGODB_RESTORE_USER:-${MONGODB_RESTORE_ENV_MONGODB_USER:-}}"
+MONGODB_PASS="${MONGODB_RESTORE_PASS:-${MONGODB_RESTORE_ENV_MONGODB_PASS:-}}"
+MONGODB_DB="${MONGODB_RESTORE_DB:-}"
 
-[[ ( -n "${MONGODB_RESTORE_USER}" ) ]] && USER_RESTORE_STR=" --username ${MONGODB_RESTORE_USER}"
-[[ ( -n "${MONGODB_RESTORE_PASS}" ) ]] && PASS_RESTORE_STR=" --password ${MONGODB_RESTORE_PASS}"
-[[ ( -n "${MONGODB_RESTORE_DB}" ) ]] && DB_RESTORE_STR=" --db ${MONGODB_RESTORE_DB}"
-
-FILE_TO_RESTORE=${1}
-
-[[ -z "${1}" ]] && FILE_TO_RESTORE=$(ls /backup -N1 | grep -iv ".tgz" | sort -r | head -n 1)
-
-echo "=> Restore database from ${FILE_TO_RESTORE}"
-if mongorestore --drop --host ${MONGODB_RESTORE_HOST} --port ${MONGODB_RESTORE_PORT} ${USER_RESTORE_STR}${PASS_RESTORE_STR}${DB_RESTORE_STR} /backup/$FILE_TO_RESTORE; then
-    echo "   Restore succeeded"
-else
-    echo "   Restore failed"
+# If password is set but user isn't, default to admin (as in original script)
+if [[ -z "${MONGODB_USER}" && -n "${MONGODB_PASS}" ]]; then
+  MONGODB_USER="admin"
 fi
+
+# Optional auth DB (recommended). Can also be passed via EXTRA_RESTORE_OPTS.
+MONGODB_AUTH_DB="${MONGODB_AUTH_DB:-${MONGODB_RESTORE_AUTH_DB:-}}"
+
+# Build mongorestore args safely
+args=(mongorestore
+  "--host" "${MONGODB_HOST}"
+  "--port" "${MONGODB_PORT}"
+  "--drop"
+)
+
+if [[ -n "${MONGODB_USER}" ]]; then
+  args+=("--username" "${MONGODB_USER}")
+fi
+if [[ -n "${MONGODB_PASS}" ]]; then
+  args+=("--password" "${MONGODB_PASS}")
+fi
+if [[ -n "${MONGODB_AUTH_DB}" ]]; then
+  args+=("--authenticationDatabase" "${MONGODB_AUTH_DB}")
+fi
+if [[ -n "${MONGODB_DB}" ]]; then
+  args+=("--db" "${MONGODB_DB}")
+fi
+
+# Determine archive to restore
+ARCHIVE_TO_RESTORE="${1:-}"
+
+if [[ -z "${ARCHIVE_TO_RESTORE}" ]]; then
+  # No argument — download latest from S3
+  : "${S3_BUCKET:?S3_BUCKET is required when no archive specified}"
+  S3_PATH="${S3_PATH:-}"
+
+  echo "=> Fetching latest archive from S3..."
+  # Look for both .archive.gz (new) and .tgz (legacy), take the latest by name
+  LATEST=$(aws s3 ls "s3://${S3_BUCKET}/${S3_PATH%/}/" 2>/dev/null | grep -E '\.(archive\.gz|tgz)$' | sort | tail -n 1 | awk '{print $4}' || true)
+
+  if [[ -z "${LATEST}" ]]; then
+    echo "=> No archives found in s3://${S3_BUCKET}/${S3_PATH%/}/" >&2
+    exit 1
+  fi
+
+  echo "   Downloading ${LATEST}"
+  aws s3 cp "s3://${S3_BUCKET}/${S3_PATH%/}/${LATEST}" "/backup/${LATEST}"
+  ARCHIVE_TO_RESTORE="/backup/${LATEST}"
+else
+  # Argument provided — use local file
+  if [[ "${ARCHIVE_TO_RESTORE}" != /* ]]; then
+    ARCHIVE_TO_RESTORE="/backup/${ARCHIVE_TO_RESTORE}"
+  fi
+fi
+
+# Handle legacy formats (.tgz or directory) — delegate to restore_legacy.sh
+if [[ "${ARCHIVE_TO_RESTORE}" == *.tgz || -d "${ARCHIVE_TO_RESTORE}" ]]; then
+  echo "=> Legacy format detected, delegating to restore_legacy.sh"
+  exec /restore_legacy.sh "${ARCHIVE_TO_RESTORE}"
+fi
+
+if [[ ! -f "${ARCHIVE_TO_RESTORE}" ]]; then
+  echo "=> Archive not found: ${ARCHIVE_TO_RESTORE}" >&2
+  exit 1
+fi
+
+# Use archive mode with gzip
+args+=("--archive=${ARCHIVE_TO_RESTORE}" "--gzip")
+
+# Allow extra options
+# Examples: EXTRA_RESTORE_OPTS="--nsInclude=mydb.*"
+if [[ -n "${EXTRA_RESTORE_OPTS:-}" ]]; then
+  # shellcheck disable=SC2206
+  extra=( ${EXTRA_RESTORE_OPTS} )
+  args+=("${extra[@]}")
+fi
+
+echo "=> Restore database from ${ARCHIVE_TO_RESTORE}"
+if "${args[@]}"; then
+  echo "   Restore succeeded"
+else
+  echo "   Restore failed" >&2
+  exit 1
+fi
+
 echo "=> Done"

--- a/restore_legacy.sh
+++ b/restore_legacy.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+set -euo pipefail
+
+# Restore from legacy backup format (directory or .tgz archive)
+# For new .archive.gz format use restore.sh
+
+# Support old Docker "link" env vars + explicit vars
+MONGODB_HOST="${MONGODB_RESTORE_PORT_27017_TCP_ADDR:-${MONGODB_RESTORE_PORT_1_27017_TCP_ADDR:-${MONGODB_RESTORE_HOST:-}}}"
+MONGODB_PORT="${MONGODB_RESTORE_PORT_27017_TCP_PORT:-${MONGODB_RESTORE_PORT_1_27017_TCP_PORT:-${MONGODB_RESTORE_PORT:-27017}}}"
+
+MONGODB_USER="${MONGODB_RESTORE_USER:-${MONGODB_RESTORE_ENV_MONGODB_USER:-}}"
+MONGODB_PASS="${MONGODB_RESTORE_PASS:-${MONGODB_RESTORE_ENV_MONGODB_PASS:-}}"
+MONGODB_DB="${MONGODB_RESTORE_DB:-}"
+
+# If password is set but user isn't, default to admin (as in original script)
+if [[ -z "${MONGODB_USER}" && -n "${MONGODB_PASS}" ]]; then
+  MONGODB_USER="admin"
+fi
+
+# Optional auth DB
+MONGODB_AUTH_DB="${MONGODB_AUTH_DB:-${MONGODB_RESTORE_AUTH_DB:-}}"
+
+# Build mongorestore args safely
+args=(mongorestore
+  "--host" "${MONGODB_HOST}"
+  "--port" "${MONGODB_PORT}"
+  "--drop"
+)
+
+if [[ -n "${MONGODB_USER}" ]]; then
+  args+=("--username" "${MONGODB_USER}")
+fi
+if [[ -n "${MONGODB_PASS}" ]]; then
+  args+=("--password" "${MONGODB_PASS}")
+fi
+if [[ -n "${MONGODB_AUTH_DB}" ]]; then
+  args+=("--authenticationDatabase" "${MONGODB_AUTH_DB}")
+fi
+if [[ -n "${MONGODB_DB}" ]]; then
+  args+=("--db" "${MONGODB_DB}")
+fi
+
+# Determine what to restore
+INPUT="${1:-}"
+TEMP_DIR=""
+
+cleanup() {
+  if [[ -n "${TEMP_DIR}" && -d "${TEMP_DIR}" ]]; then
+    rm -rf "${TEMP_DIR}"
+  fi
+}
+trap cleanup EXIT
+
+if [[ -z "${INPUT}" ]]; then
+  # Match original behavior exactly:
+  # ls /backup -N1 | grep -iv ".tgz" | sort -r | head -n 1
+  # Sort by NAME (reverse), not by date. Exclude .tgz and .archive.gz
+  FILE_TO_RESTORE=$(ls -1 /backup 2>/dev/null | grep -iv "\.tgz$" | grep -iv "\.archive\.gz$" | sort -r | head -n 1 || true)
+  if [[ -z "${FILE_TO_RESTORE}" ]]; then
+    echo "=> No legacy backup found in /backup/" >&2
+    exit 1
+  fi
+  INPUT="/backup/${FILE_TO_RESTORE}"
+else
+  # Argument provided — prepend /backup/ if relative (matches original behavior)
+  if [[ "${INPUT}" != /* ]]; then
+    INPUT="/backup/${INPUT}"
+  fi
+fi
+
+# Handle .tgz archive
+if [[ "${INPUT}" == *.tgz ]]; then
+  if [[ ! -f "${INPUT}" ]]; then
+    echo "=> Archive not found: ${INPUT}" >&2
+    exit 1
+  fi
+  echo "=> Extracting ${INPUT}"
+  TEMP_DIR=$(mktemp -d)
+  tar xzf "${INPUT}" -C "${TEMP_DIR}" --strip-components=1
+  RESTORE_PATH="${TEMP_DIR}"
+elif [[ -d "${INPUT}" ]]; then
+  RESTORE_PATH="${INPUT}"
+else
+  echo "=> Not a directory or .tgz file: ${INPUT}" >&2
+  exit 1
+fi
+
+# Allow extra options
+if [[ -n "${EXTRA_RESTORE_OPTS:-}" ]]; then
+  # shellcheck disable=SC2206
+  extra=( ${EXTRA_RESTORE_OPTS} )
+  args+=("${extra[@]}")
+fi
+
+# Add the path to restore from
+args+=("${RESTORE_PATH}")
+
+echo "=> Restore database from ${INPUT}"
+if "${args[@]}"; then
+  echo "   Restore succeeded"
+else
+  echo "   Restore failed" >&2
+  exit 1
+fi
+
+echo "=> Done"


### PR DESCRIPTION
main (allows to restore directly from s3 without downloading full archive, selectively single collection if needed):
- Switch to --archive --gzip format (single file instead of directory)

improvements:
- Add set -euo pipefail for strict error handling
- Use array for mongodump/mongorestore args (fixes issues with special chars in passwords)
- Add automatic S3 download in restore.sh
- Add restore_legacy.sh for old format (.tgz and directories)
- Fix variable fallback chain (was overwriting values)
- Add MONGODB_AUTH_DB support